### PR TITLE
Handle nonindex files

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ If a file has any inline styles, these will be hashed:
   Content-Security-Policy: style-src 'unsafe-hashes' 'sha256-0EZqoz+oBhx7gF4nvY2bSqoGyy4zLjNF+SDQXGp/ZrY='
 ```
 
+### Non-index.html files
+
+Generally, routes are generated with an `index.html` file, like `/some/file/path/index.html`.  However, sometimes you need to handle HTML files that aren't called 'index', for example `404.html` in Nuxt.
+
+These are generated as wildcard links and are placed above the non-wildcard paths in your `_headers` file (for specificity):
+
+``` txt
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'sha256-Qb2XxXiF09k6xbk2vTgHvWRed+mgYYGzFqZ6dShQVA0=';
+/specific-path/
+  Content-Security-Policy: default-src 'self';
+```
+
+Any matching wildcard URL has the hashes joined together - for example, if you have a `404.html` and a `500.html` with scripts/styles, all the hashes will be merged together under `/*`.
+
+> In general, it is better to generate `/path/index.html` rather than `/path.html`.
+
 ## Help it's all broken!
 
 Oh, you.  Chances are your browser console is screaming at you, and the network tab is showing a lot of `(blocked:csp)` errors.

--- a/functions.js
+++ b/functions.js
@@ -1,0 +1,128 @@
+const { sha256 } = require('js-sha256')
+const { JSDOM } = require('jsdom')
+
+function mergeWithDefaultPolicies (policies) {
+  const defaultPolicies = {
+    defaultSrc: '',
+    childSrc: '',
+    connectSrc: '',
+    fontSrc: '',
+    frameSrc: '',
+    imgSrc: '',
+    manifestSrc: '',
+    mediaSrc: '',
+    objectSrc: '',
+    prefetchSrc: '',
+    scriptSrc: '',
+    scriptSrcElem: '',
+    scriptSrcAttr: '',
+    styleSrc: '',
+    styleSrcElem: '',
+    styleSrcAttr: '',
+    workerSrc: '',
+    baseUri: '',
+    formAction: '',
+    frameAncestors: '',
+  }
+
+  return {...defaultPolicies, ...policies}
+}
+
+function createFileProcessor (buildDir, disableGeneratedPolicies) {
+  return path => file => {
+    const dom = new JSDOM(file)
+    const shouldGenerate = (key) => !(disableGeneratedPolicies || []).includes(key)
+    const generateHashesFromElement = generateHashes(dom, element => element.innerHTML)
+    const generateHashesFromStyle = generateHashes(dom, element => element.getAttribute('style'))
+
+    const scripts = shouldGenerate('scriptSrc') ? generateHashesFromElement('script') : []
+    const styles = shouldGenerate('styleSrc') ? generateHashesFromElement('style') : []
+    const inlineStyles = shouldGenerate('styleSrc') ? generateHashesFromStyle('[style]') : []
+
+    const indexMatcher = new RegExp(`^${buildDir}(.*)index\\.html$`)
+    const nonIndexMatcher = new RegExp(`^${buildDir}(.*\\/).*?\\.html$`)
+
+    let webPath = null
+    let globalCSP = null
+    if (path.match(indexMatcher)) {
+      webPath = path.replace(indexMatcher, '$1')
+      globalCSP = false
+    } else {
+      webPath = path.replace(nonIndexMatcher, '$1*')
+      globalCSP = true
+    }
+
+    const cspObject = {
+      scriptSrc: scripts,
+      styleSrcElem: styles,
+      styleSrc: inlineStyles,
+    }
+
+    return {
+      webPath,
+      cspObject,
+      globalCSP,
+    }
+  }
+}
+
+function generateHashes (dom, getPropertyValue) {
+  return selector => {
+    const hashes = new Set()
+    for (const matchedElement of dom.window.document.querySelectorAll(selector)) {
+      const value = getPropertyValue(matchedElement)
+      if (value.length) {
+        const hash = sha256.arrayBuffer(value)
+        const base64hash = Buffer.from(hash).toString('base64')
+        hashes.add(`'sha256-${base64hash}'`)
+      }
+    }
+    return Array.from(hashes)
+  }
+}
+
+function buildCSPArray (allPolicies, disablePolicies, hashes) {
+  const camelCaseToKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+
+  return Object.entries(allPolicies)
+    .filter(([key, defaultPolicy]) => {
+      const generatedOrDefault = (hashes[key] && hashes[key].length) || defaultPolicy
+      const notDisabled = !(disablePolicies || []).includes(key)
+      return generatedOrDefault && notDisabled
+    })
+    .map(([key, defaultPolicy]) => {
+      const policy = `${hashes[key] && hashes[key].join(' ') || ''} ${defaultPolicy}`
+      return `${camelCaseToKebabCase(key)} ${policy.trim()};`
+    })
+}
+
+function splitToGlobalAndLocal (final, header) {
+  if (header.globalCSP) {
+    const existingIndex = final.globalHeaders.findIndex(({ webPath }) => webPath === header.webPath)
+    if (existingIndex !== -1) {
+      final.globalHeaders[existingIndex].cspObject = mergeCSPObjects(final.globalHeaders, existingIndex, header.cspObject)
+    } else {
+      final.globalHeaders.push(header)
+    }
+  } else {
+    final.localHeaders.push(header)
+  }
+
+  return final
+}
+
+function mergeCSPObjects (mergeInto, index, mergeFrom) {
+  const newObject = {}
+  Object.keys(mergeInto[index].cspObject)
+    .forEach(key => {
+      newObject[key] = [].concat(...mergeInto[index].cspObject[key], ...mergeFrom[key])
+    })
+  return newObject
+}
+
+module.exports = {
+  mergeWithDefaultPolicies,
+  createFileProcessor,
+  buildCSPArray,
+  splitToGlobalAndLocal,
+}

--- a/functions.js
+++ b/functions.js
@@ -54,8 +54,7 @@ function createFileProcessor (buildDir, disableGeneratedPolicies) {
 
     const cspObject = {
       scriptSrc: scripts,
-      styleSrcElem: styles,
-      styleSrc: inlineStyles,
+      styleSrc: [...inlineStyles, ...styles],
     }
 
     return {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const fs = require('fs')
 const { performance } = require('perf_hooks')
 const globby = require('globby')
-const { sha256 } = require('js-sha256')
-const { JSDOM } = require('jsdom')
+
+const { mergeWithDefaultPolicies, createFileProcessor, buildCSPArray, splitToGlobalAndLocal } = require('./functions.js')
 
 module.exports = {
   onPostBuild: async ({ inputs }) => {
@@ -19,96 +19,24 @@ module.exports = {
     const paths = await globby(lookup)
     console.info(`Found ${paths.length} HTML ${paths.length === 1 ? 'file' : 'files'}`)
 
-    const processFile = createFileProcessor(buildDir, mergedPolicies, disablePolicies, disableGeneratedPolicies)
+    const processFile = createFileProcessor(buildDir, disableGeneratedPolicies)
 
     const processedFileHeaders = await Promise.all(
       paths.map(path => fs.promises.readFile(path, 'utf-8').then(processFile(path)))
     )
 
-    const file = processedFileHeaders
-      .map(({ webPath, cspString }) => `${webPath}\n  Content-Security-Policy: ${cspString}`)
-      .join('\n')
+    const { globalHeaders, localHeaders } = processedFileHeaders
+      .reduce(splitToGlobalAndLocal, { globalHeaders: [], localHeaders: [] })
+
+    const file = globalHeaders.concat(...localHeaders)
+      .map(({ webPath, cspObject }) => {
+        const cspString = buildCSPArray(mergedPolicies, disablePolicies, cspObject).join(' ')
+        return `${webPath}\n  Content-Security-Policy: ${cspString}`
+      }).join('\n')
 
     fs.appendFileSync(`${buildDir}/_headers`, file)
 
     const completedTime = performance.now() - startTime
     console.info(`Saved at ${buildDir}/_headers - ${(completedTime / 1000).toFixed(2)} seconds`)
   },
-}
-
-function mergeWithDefaultPolicies (policies) {
-  const defaultPolicies = {
-    defaultSrc: '',
-    childSrc: '',
-    connectSrc: '',
-    fontSrc: '',
-    frameSrc: '',
-    imgSrc: '',
-    manifestSrc: '',
-    mediaSrc: '',
-    objectSrc: '',
-    prefetchSrc: '',
-    scriptSrc: '',
-    scriptSrcElem: '',
-    scriptSrcAttr: '',
-    styleSrc: '',
-    styleSrcElem: '',
-    styleSrcAttr: '',
-    workerSrc: '',
-    baseUri: '',
-    formAction: '',
-    frameAncestors: '',
-  }
-
-  return {...defaultPolicies, ...policies}
-}
-
-function createFileProcessor (buildDir, mergedPolicies, disablePolicies, disableGeneratedPolicies) {
-  return path => file => {
-    const dom = new JSDOM(file)
-    const shouldGenerate = (key) => !(disableGeneratedPolicies || []).includes(key)
-    const generateHashesFromElement = generateHashes(dom, element => element.innerHTML)
-    const generateHashesFromStyle = generateHashes(dom, element => element.getAttribute('style'))
-
-    const scripts = shouldGenerate('scriptSrc') ? generateHashesFromElement('script') : []
-    const styles = shouldGenerate('styleSrc') ? generateHashesFromElement('style') : []
-    const inlineStyles = shouldGenerate('styleSrc') ? generateHashesFromStyle('[style]') : []
-
-    const webPath = path.replace(new RegExp(`^${buildDir}(.*)index\\.html$`), '$1')
-    const cspString = buildCSPArray(mergedPolicies, disablePolicies, {
-      scriptSrc: scripts,
-      styleSrc: [...styles, ...inlineStyles],
-    }).join(' ')
-
-    return {
-      webPath,
-      cspString,
-    }
-  }
-}
-
-function generateHashes (dom, getPropertyValue) {
-  return selector => {
-    const hashes = new Set()
-    for (const matchedElement of dom.window.document.querySelectorAll(selector)) {
-      const value = getPropertyValue(matchedElement)
-      if (value.length) {
-        const hash = sha256.arrayBuffer(value)
-        const base64hash = Buffer.from(hash).toString('base64')
-        hashes.add(`'sha256-${base64hash}'`)
-      }
-    }
-    return Array.from(hashes)
-  }
-}
-
-function buildCSPArray (allPolicies, disablePolicies, hashes) {
-  const camelCaseToKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
-
-  return Object.entries(allPolicies)
-    .filter(([key, defaultPolicy]) => (hashes[key] || defaultPolicy) && !(disablePolicies || []).includes(key))
-    .map(([key, defaultPolicy]) => {
-      const policy = `${hashes[key] && hashes[key].join(' ') || ''} ${defaultPolicy}`;
-      return `${camelCaseToKebabCase(key)} ${policy.trim()};`
-    })
 }


### PR DESCRIPTION
Fixes #4

This considers any path that isn't an `index.html` file as a wildcard, i.e. [404.html](#) resolves to `/*` in `_headers`.

Paths try to be as minimal as possible, so if you have [/some/nested/file/path/404.html](#) it will resolve to `/some/nested/file/path/*`.

All wildcard files are merged, so `404.html` and `500.html` would receive the same CSP header with properties from both.